### PR TITLE
[WIP] add a use_timestamp option to image form type

### DIFF
--- a/src/Form/Type/FileType.php
+++ b/src/Form/Type/FileType.php
@@ -98,6 +98,6 @@ class FileType extends AbstractType
      */
     public function configureOptions(OptionsResolver $options)
     {
-        $options->setDefaults(['data_class' => $this->dataClass]);
+        $options->setDefaults(['data_class' => $this->dataClass, 'child_of_node' => null]);
     }
 }

--- a/src/Form/Type/ImageType.php
+++ b/src/Form/Type/ImageType.php
@@ -80,6 +80,7 @@ class ImageType extends FileType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['imagine_filter'] = $this->useImagine ? $options['imagine_filter'] : false;
+        $view->vars['use_timestamp'] = $options['use_timestamp'];
     }
 
     /**
@@ -88,6 +89,6 @@ class ImageType extends FileType
     public function configureOptions(OptionsResolver $options)
     {
         parent::configureOptions($options);
-        $options->setDefaults(['imagine_filter' => $this->defaultFilter]);
+        $options->setDefaults(['imagine_filter' => $this->defaultFilter, 'use_timestamp' => false]);
     }
 }

--- a/src/Resources/views/Form/fields.html.twig
+++ b/src/Resources/views/Form/fields.html.twig
@@ -2,7 +2,7 @@
     {{ form_widget(form) }}
     {% block cmf_media_image_widget_preview %}
         {% if form.vars.data and form.vars.data.id is defined and form.vars.data.id %}
-                <img src="{{ cmf_media_display_url(form.vars.data, { imagine_filter : imagine_filter }) }}" alt="" {% if not imagine_filter %}width="100"{% endif %} />
+                <img src="{{ cmf_media_display_url(form.vars.data, { imagine_filter : imagine_filter }) }}{% if form.vars.use_timestamp is defined and form.vars.use_timestamp %}{{ '?'~form.vars.use_timestamp }}{% endif %}" alt="" {% if not imagine_filter %}width="100"{% endif %} />
         {% endif %}
     {% endblock %}
 {% endblock %}


### PR DESCRIPTION

To trick the browser cache it would be nice to have a little timestamp apendet to the image path.

ToDo:

* [x] Form option
* [ ] Tests
* [ ] Configuration item as default

Hint: 
this branch is pushed from a working app and will be completed later.