### PR TITLE
Elfinder bundle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         "liip/imagine-bundle": "To integrate with the Imagine library for processing images",
         "helios-ag/fm-elfinder-bundle": "When using the elFinder media browser"
     },
+    "conflict": {
+        "helios-ag/fm-elfinder-bundle": "<8.0"
+    },
     "autoload": {
         "psr-4": {
             "Symfony\\Cmf\\Bundle\\MediaBundle\\": "src/"

--- a/src/Adapter/ElFinder/PhpcrDriver.php
+++ b/src/Adapter/ElFinder/PhpcrDriver.php
@@ -15,7 +15,6 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\Document\Generic;
 use Doctrine\ODM\PHPCR\Document\Resource;
 use Doctrine\ODM\PHPCR\DocumentManager;
-use FM\ElFinderPHP\Driver\ElFinderVolumeDriver;
 use Imagine\Filter\ FilterInterface;
 use PHPCR\Util\PathHelper;
 use Symfony\Cmf\Bundle\MediaBundle\DirectoryInterface;
@@ -31,7 +30,7 @@ use Symfony\Cmf\Bundle\MediaBundle\Templating\Helper\CmfMediaHelper;
 /**
  * @author Sjoerd Peters <sjoerd.peters@gmail.com>
  */
-class PhpcrDriver extends ElFinderVolumeDriver
+class PhpcrDriver extends \elFinderVolumeDriver
 {
     /**
      * Driver id

--- a/src/Adapter/ElFinder/PhpcrDriver.php
+++ b/src/Adapter/ElFinder/PhpcrDriver.php
@@ -53,7 +53,7 @@ class PhpcrDriver extends \elFinderVolumeDriver
     /**
      * @var array
      */
-    private $options;
+    protected $options;
 
     /**
      * Constructor.


### PR DESCRIPTION
helios-ag/fm-elfinder-bundle uses Studio-42/elFinder instead of helios-ag/ElFinderPHP (https://github.com/helios-ag/FMElfinderBundle/releases/tag/8.0)